### PR TITLE
Add link to nightly std

### DIFF
--- a/redirects.toml
+++ b/redirects.toml
@@ -67,6 +67,10 @@ short = "std"
 url = "https://doc.rust-lang.org/stable/std"
 
 [[redirect]]
+short = "nightly"
+url = "https://doc.rust-lang.org/nightly/std"
+
+[[redirect]]
 short = "toolstate"
 url = "https://rust-lang-nursery.github.io/rust-toolstate/"
 


### PR DESCRIPTION
The nightly std docs use the newest features from `rustdoc` improvements. Right now there's a significant difference in behavior around collapsible sections.

An alternative is to simply link to the nightly version of std docs by default. Ultimately, it's the same docs.